### PR TITLE
Optional ImageRunnerOptions properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ A user provides a target image, and the algorithm finds shapes to approximate th
 
 ## JavaScript Usage
 
-If you are working in JavaScript, check out the [geometrize-js](https://github.com/cancerberoSgx/geometrizejs) API and [npm](https://www.npmjs.com/package/geometrizejs) package.
+If you are working in JavaScript, check out [geometrizejs](https://www.npmjs.com/package/geometrizejs) which provides JavaScript API and types for this library, tested on browser and Node.js.
+
+On top of it, [geometrizejs-cli](https://www.npmjs.com/package/geometrizejs-cli) tool provides command line interface and support for common image formats.
 
 ## Haxe Install
 

--- a/geometrize/Util.hx
+++ b/geometrize/Util.hx
@@ -150,5 +150,4 @@ class Util {
 		}
 		return value;
 	}
-
 }

--- a/geometrize/Util.hx
+++ b/geometrize/Util.hx
@@ -151,13 +151,4 @@ class Util {
 		return value;
 	}
 
-	public static function objectAssign<T>(o1:Dynamic, o2:Dynamic, o3:Dynamic):T {
-		var fields = Reflect.fields(o1).concat(Reflect.fields(o2)).concat(Reflect.fields(o3)); // TODO: dedup
-		for (f in fields) {
-			var v = Reflect.field(o3, f) || Reflect.field(o2, f) || Reflect.field(o1, f);
-			Reflect.setField(o1, f, v);
-		}
-		return o1;
-	}
-
 }

--- a/geometrize/Util.hx
+++ b/geometrize/Util.hx
@@ -150,4 +150,14 @@ class Util {
 		}
 		return value;
 	}
+
+	public static function objectAssign<T>(o1:Dynamic, o2:Dynamic, o3:Dynamic):T {
+		var fields = Reflect.fields(o1).concat(Reflect.fields(o2)).concat(Reflect.fields(o3)); // TODO: dedup
+		for (f in fields) {
+			var v = Reflect.field(o3, f) || Reflect.field(o2, f) || Reflect.field(o1, f);
+			Reflect.setField(o1, f, v);
+		}
+		return o1;
+	}
+
 }

--- a/geometrize/runner/ImageRunner.hx
+++ b/geometrize/runner/ImageRunner.hx
@@ -4,6 +4,8 @@ import geometrize.Model;
 import geometrize.Model.ShapeResult;
 import geometrize.bitmap.Bitmap;
 import geometrize.bitmap.Rgba;
+import geometrize.Util;
+import geometrize.runner.ImageRunnerOptions.Default;
 
 /**
  * Helper class for creating a set of shapes that approximate a source image.
@@ -15,7 +17,7 @@ class ImageRunner {
 	 * The model for the optimization/fitting algorithm.
 	 */
 	public var model(default, null):Model = null;
-	
+
 	/**
 	 * Creates a new runner.
 	 * @param	inputImage	The input image, the image that the algorithm will optimize for.
@@ -23,15 +25,16 @@ class ImageRunner {
 	public function new(inputImage:Bitmap, backgroundColor:Rgba) {
 		model = new Model(inputImage, backgroundColor);
 	}
-	
+
 	/**
 	 * Updates the model once.
 	 * @return	An array containing data about the shapes just added to the model.
 	 */
 	public function step(options:ImageRunnerOptions):Array<ShapeResult> {
-		return model.step(options.shapeTypes, options.alpha, options.candidateShapesPerStep, options.shapeMutationsPerStep);
+		var finalOptions:ImageRunnerOptions = Util.objectAssign({}, Default.options, options);
+		return model.step(finalOptions.shapeTypes, finalOptions.alpha, finalOptions.candidateShapesPerStep, finalOptions.shapeMutationsPerStep);
 	}
-	
+
 	/**
 	 * Gets the current bitmap with the shapes drawn on it.
 	 * @return	The current bitmap.

--- a/geometrize/runner/ImageRunner.hx
+++ b/geometrize/runner/ImageRunner.hx
@@ -4,7 +4,6 @@ import geometrize.Model;
 import geometrize.Model.ShapeResult;
 import geometrize.bitmap.Bitmap;
 import geometrize.bitmap.Rgba;
-import geometrize.Util;
 import geometrize.runner.ImageRunnerOptions.Default;
 
 /**

--- a/geometrize/runner/ImageRunner.hx
+++ b/geometrize/runner/ImageRunner.hx
@@ -23,7 +23,7 @@ class ImageRunner {
 	 * @param	inputImage	The input image, the image that the algorithm will optimize for.
 	 */
 	public function new(inputImage:Bitmap, backgroundColor:Rgba) {
-		model = new Model(inputImage, backgroundColor);
+    model = new Model(inputImage, backgroundColor);
 	}
 
 	/**
@@ -31,7 +31,12 @@ class ImageRunner {
 	 * @return	An array containing data about the shapes just added to the model.
 	 */
 	public function step(options:ImageRunnerOptions):Array<ShapeResult> {
-		var finalOptions:ImageRunnerOptions = Util.objectAssign({}, Default.options, options);
+		var finalOptions:ImageRunnerOptions = {
+      shapeTypes: options.shapeTypes && options.shapeTypes.length ? options.shapeTypes : Default.options.shapeTypes,
+      alpha: options.alpha || Default.options.alpha,
+      candidateShapesPerStep: options.candidateShapesPerStep || Default.options.candidateShapesPerStep,
+      shapeMutationsPerStep: options.shapeMutationsPerStep || Default.options.shapeMutationsPerStep
+    };
 		return model.step(finalOptions.shapeTypes, finalOptions.alpha, finalOptions.candidateShapesPerStep, finalOptions.shapeMutationsPerStep);
 	}
 

--- a/geometrize/runner/ImageRunner.hx
+++ b/geometrize/runner/ImageRunner.hx
@@ -23,7 +23,7 @@ class ImageRunner {
 	 * @param	inputImage	The input image, the image that the algorithm will optimize for.
 	 */
 	public function new(inputImage:Bitmap, backgroundColor:Rgba) {
-    model = new Model(inputImage, backgroundColor);
+		model = new Model(inputImage, backgroundColor);
 	}
 
 	/**
@@ -32,11 +32,11 @@ class ImageRunner {
 	 */
 	public function step(options:ImageRunnerOptions):Array<ShapeResult> {
 		var finalOptions:ImageRunnerOptions = {
-      shapeTypes: options.shapeTypes && options.shapeTypes.length ? options.shapeTypes : Default.options.shapeTypes,
-      alpha: options.alpha || Default.options.alpha,
-      candidateShapesPerStep: options.candidateShapesPerStep || Default.options.candidateShapesPerStep,
-      shapeMutationsPerStep: options.shapeMutationsPerStep || Default.options.shapeMutationsPerStep
-    };
+			shapeTypes: options.shapeTypes != null && options.shapeTypes.length != 0 ? options.shapeTypes : Default.options.shapeTypes,
+			alpha: options.alpha != null ? options.alpha : Default.options.alpha,
+			candidateShapesPerStep: options.candidateShapesPerStep != null ? options.candidateShapesPerStep : Default.options.candidateShapesPerStep,
+			shapeMutationsPerStep: options.shapeMutationsPerStep != null ? options.shapeMutationsPerStep : Default.options.shapeMutationsPerStep
+		};
 		return model.step(finalOptions.shapeTypes, finalOptions.alpha, finalOptions.candidateShapesPerStep, finalOptions.shapeMutationsPerStep);
 	}
 

--- a/geometrize/runner/ImageRunnerOptions.hx
+++ b/geometrize/runner/ImageRunnerOptions.hx
@@ -30,7 +30,7 @@ typedef ImageRunnerOptions = {
 }
 
 class Default {
-	public static var options = {
+	public static var options:ImageRunnerOptions = {
 		shapeTypes: [ShapeType.TRIANGLE],
 		candidateShapesPerStep: 50,
 		shapeMutationsPerStep: 100,

--- a/geometrize/runner/ImageRunnerOptions.hx
+++ b/geometrize/runner/ImageRunnerOptions.hx
@@ -9,22 +9,31 @@ import geometrize.shape.ShapeType;
 @:expose
 typedef ImageRunnerOptions = {
 	/**
-	 * The types of shapes to use when generating the image.
+	 * The types of shapes to use when generating the image. By default `[ShapeType.TRIANGLE]`.
 	 */
-	var shapeTypes:Array<ShapeType>;
-	
+	@:optional var shapeTypes:Array<ShapeType>;
+
 	/**
-	 * The opacity of the shapes (0-255).
+	 * The opacity of the shapes (0-255). By default `128`.
 	 */
-	var alpha:Int;
-	
+	@:optional var alpha:Int;
+
 	/**
-	 * The number of candidate shapes to try per model step.
+	 * The number of candidate shapes to try per model step. By default `50`.
 	 */
-	var candidateShapesPerStep:Int;
-	
+	@:optional var candidateShapesPerStep:Int;
+
 	/**
-	 * The number of times to mutate each candidate shape.
+	 * The number of times to mutate each candidate shape. By default `100`.
 	 */
-	var shapeMutationsPerStep:Int;
+	@:optional var shapeMutationsPerStep:Int;
+}
+
+class Default {
+	public static var options = {
+		shapeTypes: [ShapeType.TRIANGLE],
+		candidateShapesPerStep: 50,
+		shapeMutationsPerStep: 100,
+		alpha: 128
+	};
 }


### PR DESCRIPTION
Right now all ImageRunnerOptions are mandatory and new users basically need to find and copy/paste their values from an example in order to make it work. No matter if they understand options semantics is imposible for them to know which values or at which scale makes sense. 

This PR has option defaults and declare all options as optional, Then in the runner default options are mixed with user's to build the final ones currently used.This way users can just call runner.step() passing an empty object or an object with just the options they want to customize.

If this acceptable for you,  the only missing part I would like you to define is the default values that make a fast/nice result.

It's working fine in my projects although I didn't run unit-tests yet