### PR TITLE
bitmapOffset - run only inside a given bitmap region

### DIFF
--- a/geometrize/Core.hx
+++ b/geometrize/Core.hx
@@ -97,6 +97,7 @@ class Core {
 			}
 		}
 		var result:Float = Math.sqrt(total / (width * height * 4.0)) / 255;
+    // trace('differenceFull: '+total+", "+width+", "+height+", "+result+", "+Math.isFinite(result));
 		Sure.sure(Math.isFinite(result));
 		return result;
 	}
@@ -144,6 +145,8 @@ class Core {
 			}
 		}
 		var result:Float = Math.sqrt(total / rgbaCount) / 255;
+    // trace('differencePartial: '+total+", "+rgbaCount+", "+result+", "+Math.isFinite(result));
+
 		Sure.sure(Math.isFinite(result));
 		return result;
 	}

--- a/geometrize/Model.hx
+++ b/geometrize/Model.hx
@@ -74,10 +74,11 @@ class Model {
 
 		this.score = Core.differenceFull(target, current);
 	}
-  
+
   /**
    * The algorithm will only consider a region of the entire bitmap. 
    * New shapes will be generated randombly but only inside this region.
+   * If null is passed it will reset the offset (default behaviour)
   **/
 	public inline function setOffset(?offset:Util.Rect):Void {
 		this.current.setOffset(offset);

--- a/geometrize/Model.hx
+++ b/geometrize/Model.hx
@@ -7,6 +7,7 @@ import geometrize.rasterizer.Scanline;
 import geometrize.shape.Shape;
 import geometrize.shape.ShapeType;
 import geometrize.rasterizer.Rasterizer;
+import geometrize.Util;
 
 /**
  * Container for info about a shape added to the model.
@@ -73,6 +74,19 @@ class Model {
 
 		this.score = Core.differenceFull(target, current);
 	}
+  
+  /**
+   * The algorithm will only consider a region of the entire bitmap. 
+   * New shapes will be generated randombly but only inside this region.
+  **/
+	public inline function setOffset(?offset:Util.Rect):Void {
+		this.current.setOffset(offset);
+		this.current.setOffset(offset);
+		this.target.setOffset(offset);
+		this.width = target.width;
+		this.height = target.height;
+		this.score = Core.differenceFull(target, current);
+	}
 
 	/**
 	 * Steps the optimization/fitting algorithm.
@@ -84,7 +98,7 @@ class Model {
 	 */
 	public function step(shapeTypes:Array<ShapeType>, alpha:Int, n:Int, age:Int):Array<ShapeResult> {
 		var state = Core.bestHillClimbState(shapeTypes, alpha, n, age, target, current, buffer, score);
-		var results:Array<ShapeResult> = [ addShape(state.shape, state.alpha) ];
+		var results:Array<ShapeResult> = [addShape(state.shape, state.alpha)];
 		return results;
 	}
 
@@ -108,7 +122,7 @@ class Model {
 		if (currentOffset != null) {
 			shape.translate(currentOffset);
 		}
-    
+
 		var result:ShapeResult = {
 			score: score,
 			color: color,

--- a/geometrize/State.hx
+++ b/geometrize/State.hx
@@ -11,10 +11,12 @@ class State {
 	 * The geometric shape owned by the state.
 	 */
 	public var shape(default, null):Shape;
+
 	/**
 	 * The alpha of the shape.
 	 */
 	public var alpha(default, null):Int;
+  
 	/**
 	 * The score of the state, a measure of the improvement applying the state to the current bitmap will have.
 	 */

--- a/geometrize/Util.hx
+++ b/geometrize/Util.hx
@@ -18,9 +18,8 @@ typedef Point = {
  */
 typedef Rect = {
 	> Point,
-	;
-	w:Int;
-	h:Int;
+	w:Int,
+	h:Int
 }
 
 /**

--- a/geometrize/Util.hx
+++ b/geometrize/Util.hx
@@ -4,7 +4,7 @@ import geometrize.bitmap.Bitmap;
 import geometrize.bitmap.Rgba;
 
 /**
- * Represents a point in 2D space.
+ * Represents a point or vector in 2D space. 
  * @author Sam Twidale (http://samcodes.co.uk/)
  */
 typedef Point = {

--- a/geometrize/Util.hx
+++ b/geometrize/Util.hx
@@ -18,8 +18,8 @@ typedef Point = {
  */
 typedef Rect = {
 	> Point,
-	w:Int,
-	h:Int
+	width:Int,
+	height:Int
 }
 
 /**

--- a/geometrize/Util.hx
+++ b/geometrize/Util.hx
@@ -13,6 +13,17 @@ typedef Point = {
 }
 
 /**
+ * Represents a rectangle in 2D space.
+ * @author Sam Twidale (http://samcodes.co.uk/)
+ */
+typedef Rect = {
+	> Point,
+	;
+	w:Int;
+	h:Int;
+}
+
+/**
  * Utility functions.
  * @author Sam Twidale (http://samcodes.co.uk/)
  */
@@ -25,11 +36,11 @@ class Util {
 	 */
 	public static function getAverageImageColor(image:Bitmap, alpha:Int = 255):Rgba {
 		Sure.sure(image != null);
-		
+
 		var totalRed:Int = 0;
 		var totalGreen:Int = 0;
 		var totalBlue:Int = 0;
-		
+
 		for (x in 0...image.width) {
 			for (y in 0...image.height) {
 				var pixel = image.getPixel(x, y);
@@ -38,11 +49,11 @@ class Util {
 				totalBlue += pixel.b;
 			}
 		}
-		
+
 		var size:Int = image.width * image.height;
 		return Rgba.create(Std.int(totalRed / size), Std.int(totalGreen / size), Std.int(totalBlue / size), alpha);
 	}
-	
+
 	/**
 	 * Clamps a value within a range.
 	 * @param	value	The value to clamp.
@@ -54,7 +65,7 @@ class Util {
 		Sure.sure(min <= max);
 		return value < min ? min : value > max ? max : value;
 	}
-	
+
 	/**
 	 * Compares two values and returns the smaller one.
 	 * @param	first	The first value.
@@ -64,7 +75,7 @@ class Util {
 	public static inline function min(first:Int, second:Int):Int {
 		return first < second ? first : second;
 	}
-	
+
 	/**
 	 * Compare two values and returns the larger one.
 	 * @param	first	The first value.
@@ -74,7 +85,7 @@ class Util {
 	public static inline function max(first:Int, second:Int):Int {
 		return first > second ? first : second;
 	}
-	
+
 	/**
 	 * Converts a value measured in degrees to radians.
 	 * @param	degrees	Degrees value to convert to radians.
@@ -83,7 +94,7 @@ class Util {
 	public static inline function toRadians(degrees:Float):Float {
 		return degrees * Math.PI / 180;
 	}
-	
+
 	/**
 	 * Converts a value measured in radians to degrees.
 	 * @param	radians	Radians value to convert to degrees.
@@ -92,7 +103,7 @@ class Util {
 	public static inline function toDegrees(radians:Float):Float {
 		return radians * 180 / Math.PI;
 	}
-	
+
 	/**
 	 * Returns a random integer in the range (inclusive).
 	 * @param	lower	The lower bound.
@@ -103,7 +114,7 @@ class Util {
 		Sure.sure(lower <= upper);
 		return lower + Math.floor((upper - lower + 1) * Math.random());
 	}
-	
+
 	/**
 	 * Returns a random item from an array.
 	 * @param	a	The array to pick a random item from.
@@ -113,7 +124,7 @@ class Util {
 		Sure.sure(a != null && a.length > 0);
 		return a[random(0, a.length - 1)];
 	}
-	
+
 	/**
 	 * Returns the smallest and largest items from an array of ints.
 	 * @param	a	The array of ints.
@@ -121,12 +132,12 @@ class Util {
 	 */
 	public static inline function minMaxElements(a:Array<Int>):Point {
 		if (a == null || a.length == 0) {
-			return { x : 0, y : 0 };
+			return {x: 0, y: 0};
 		}
-		
+
 		var min:Int = a[0];
 		var max:Int = a[0];
-		
+
 		for (value in a) {
 			if (min > value) {
 				min = value;
@@ -135,10 +146,10 @@ class Util {
 				max = value;
 			}
 		}
-		
-		return { x: min, y: max };
+
+		return {x: min, y: max};
 	}
-	
+
 	/**
 	 * Returns the absolute value of the given value.
 	 * @param	value The value to abs.

--- a/geometrize/bitmap/Bitmap.hx
+++ b/geometrize/bitmap/Bitmap.hx
@@ -46,34 +46,41 @@ class OffsetArea {
 	}
   
   /**
-  @returns current offset or null if none.
+  * @returns current offset or null if none.
   **/
-public inline function getOffSet()  {
-  if(width!=originalWidth||height!=originalHeight||offsetX!=0||offsetY!=0){
-    return {x:offsetX, y: offsetY, width: width, height: height };
+  public inline function getOffSet()  {
+    if(width!=originalWidth||height!=originalHeight||offsetX!=0||offsetY!=0){
+      return {x:offsetX, y: offsetY, width: width, height: height };
+    }
+    return null;
   }
-  return null;
-}
 
-/**
- * Saves current offset overriding previous saves.
- * @param reset if given it will also remove current offset.
- */
-public function saveOffSet(?reset: Bool) {
-  savedOffset=getOffSet();
-  if(reset){
-    setOffset();
+  /**
+  * Saves current offset overriding previous saves.
+  * @param reset if given it will also remove current offset.
+  */
+  public function saveOffSet(?reset: Bool) {
+    savedOffset=getOffSet();
+    if(reset){
+      setOffset();
+    }
   }
-}
 
-/**
- * Restores previously saved offset, if any.
- */
-public function restoreOffset() {
-  if(savedOffset!=null){
-  setOffset(savedOffset);
+  /**
+  * Restores previously saved offset, if any.
+  */
+  public function restoreOffset() {
+    if(savedOffset!=null){
+    setOffset(savedOffset);
+    }
   }
-}
+
+	private inline function getCoordsIndex(x:Int, y:Int) {
+		var absoluteStart = offsetY * originalWidth + offsetX;
+		var absoluteIndex = (originalWidth * y)  + x; 
+		var index = absoluteStart + absoluteIndex ;
+		return index;
+	}
 
 }
 
@@ -179,13 +186,6 @@ class Bitmap extends OffsetArea {
 	 */
 	public inline function setPixel(x:Int, y:Int, color:Rgba):Void {
 		data.set(getCoordsIndex(x, y), color);
-	}
-
-	private inline function getCoordsIndex(x:Int, y:Int) {
-		var absoluteStart = offsetY * originalWidth + offsetX;
-		var absoluteIndex = (originalWidth * y)  + x -offsetX;//-(originalWidth-offsetX);  
-		var index = absoluteStart + absoluteIndex ;
-		return index;
 	}
 
 	/**

--- a/geometrize/bitmap/Bitmap.hx
+++ b/geometrize/bitmap/Bitmap.hx
@@ -20,6 +20,7 @@ class OffsetArea {
 	private var offsetX:Int;
 	private var offsetY:Int;
 	@:optional private var savedOffset:Util.Rect;
+
 	/**
 	 * Sets the bitmap offset, this is, a region inside relative to which pixel read and write operations are made.
 	 * Calling this method without parameters will remove the offset and reset to default behavior.
@@ -31,7 +32,6 @@ class OffsetArea {
 			offsetX = 0;
 			offsetY = 0;
 		} else {
-      trace((offset.x + offset.width)+' - '+originalWidth);
 			Sure.sure(offset.width>0);
       Sure.sure(offset.x + offset.width <= originalWidth);
 			Sure.sure(offset.height > 0);
@@ -44,6 +44,10 @@ class OffsetArea {
 			offsetY = offset.y;
 		}
 	}
+  
+  /**
+  @returns current offset or null if none.
+  **/
 public inline function getOffSet()  {
   if(width!=originalWidth||height!=originalHeight||offsetX!=0||offsetY!=0){
     return {x:offsetX, y: offsetY, width: width, height: height };
@@ -51,13 +55,20 @@ public inline function getOffSet()  {
   return null;
 }
 
-public function saveOffSet(?resetOffset: Bool) {
+/**
+ * Saves current offset overriding previous saves.
+ * @param reset if given it will also remove current offset.
+ */
+public function saveOffSet(?reset: Bool) {
   savedOffset=getOffSet();
-  if(resetOffset){
+  if(reset){
     setOffset();
   }
 }
 
+/**
+ * Restores previously saved offset, if any.
+ */
 public function restoreOffset() {
   if(savedOffset!=null){
   setOffset(savedOffset);

--- a/geometrize/bitmap/Bitmap.hx
+++ b/geometrize/bitmap/Bitmap.hx
@@ -4,93 +4,12 @@ import haxe.ds.Vector;
 import haxe.io.Bytes;
 import geometrize.Util;
 
-class OffsetArea {
-	/**
-	 * The width of the bitmap considering its offset, if any.
-	 */
-	public var width:Int;
-
-	/**
-	 * The height of the bitmap considering its offset, if any.
-	 */
-	public var height:Int;
-
-	private var originalWidth:Int;
-	private var originalHeight:Int;
-	private var offsetX:Int;
-	private var offsetY:Int;
-	@:optional private var savedOffset:Util.Rect;
-
-	/**
-	 * Sets the bitmap offset, this is, a region inside relative to which pixel read and write operations are made.
-	 * Calling this method without parameters will remove the offset and reset to default behavior.
-	**/
-	public inline function setOffset(?offset:Util.Rect):Void {
-		if (offset == null) {
-			width = originalWidth;
-			height = originalHeight;
-			offsetX = 0;
-			offsetY = 0;
-		} else {
-			Sure.sure(offset.width>0);
-      Sure.sure(offset.x + offset.width <= originalWidth);
-			Sure.sure(offset.height > 0);
-      Sure.sure(offset.y + offset.height <= originalHeight);
-			Sure.sure(offset.x >= 0);
-			Sure.sure(offset.y >= 0);
-			width = offset.width;
-			height = offset.height;
-			offsetX = offset.x;
-			offsetY = offset.y;
-		}
-	}
-  
-  /**
-  * @returns current offset or null if none.
-  **/
-  public inline function getOffSet()  {
-    if(width!=originalWidth||height!=originalHeight||offsetX!=0||offsetY!=0){
-      return {x:offsetX, y: offsetY, width: width, height: height };
-    }
-    return null;
-  }
-
-  /**
-  * Saves current offset overriding previous saves.
-  * @param reset if given it will also remove current offset.
-  */
-  public function saveOffSet(?reset: Bool) {
-    savedOffset=getOffSet();
-    if(reset){
-      setOffset();
-    }
-  }
-
-  /**
-  * Restores previously saved offset, if any.
-  */
-  public function restoreOffset() {
-    if(savedOffset!=null){
-    setOffset(savedOffset);
-    }
-  }
-
-	private inline function getCoordsIndex(x:Int, y:Int) {
-		var absoluteStart = offsetY * originalWidth + offsetX;
-		var absoluteIndex = (originalWidth * y)  + x; 
-		var index = absoluteStart + absoluteIndex ;
-		return index;
-	}
-
-}
-
 /**
  * Helper class for working with bitmap data.
  * @author Sam Twidale (http://samcodes.co.uk/)
  */
 @:expose
 class Bitmap extends OffsetArea {
-
 	/**
 	 * The bitmap data.
 	 */
@@ -194,7 +113,7 @@ class Bitmap extends OffsetArea {
 	 */
 	public inline function clone():Bitmap {
 		var bitmap = createBitmapOfLength(originalWidth, originalHeight, data.length);
-    bitmap.setOffset(getOffSet());
+		bitmap.setOffset(getOffSet());
 		for (i in 0...data.length) {
 			bitmap.data.set(i, data.get(i));
 		}

--- a/geometrize/bitmap/OffsetArea.hx
+++ b/geometrize/bitmap/OffsetArea.hx
@@ -7,7 +7,7 @@ import geometrize.Util;
  * internal rectangular offset (offsetX, offsetY, width, height). 
  **/
 class OffsetArea {
-  
+
 	/**
 	 * The width of the bitmap considering its offset, if any.
 	 */
@@ -85,9 +85,9 @@ class OffsetArea {
 	}
 
   /**
-   * Convert coordinates relative relative to the offset into absolute coordinatess.
+   * Convert coordinates relative to the offset into absolute coordinates in array index coordinates.
    **/
-	private inline function getCoordsIndex(x:Int, y:Int) {
+	public inline function getCoordsIndex(x:Int, y:Int) {
 		var absoluteStart = offsetY * originalWidth + offsetX;
 		var absoluteIndex = (originalWidth * y) + x;
 		var index = absoluteStart + absoluteIndex;

--- a/geometrize/bitmap/OffsetArea.hx
+++ b/geometrize/bitmap/OffsetArea.hx
@@ -1,0 +1,96 @@
+package geometrize.bitmap;
+
+import geometrize.Util;
+
+/**
+ * Base class implementing a rectangular area (originalWidth, originalHeight) with an 
+ * internal rectangular offset (offsetX, offsetY, width, height). 
+ **/
+class OffsetArea {
+  
+	/**
+	 * The width of the bitmap considering its offset, if any.
+	 */
+	public var width:Int;
+
+	/**
+	 * The height of the bitmap considering its offset, if any.
+	 */
+	public var height:Int;
+
+	private var originalWidth:Int;
+	private var originalHeight:Int;
+	private var offsetX:Int;
+	private var offsetY:Int;
+	@:optional private var savedOffset:Util.Rect;
+
+  /**
+   * The algorithm will only consider a region of the entire bitmap. 
+   * If null is passed it will reset the offset (default behaviour)
+   * New shapes will be generated randombly but only inside this region.
+  **/
+	public inline function setOffset(?offset:Util.Rect):Void {
+		if (offset == null) {
+			width = originalWidth;
+			height = originalHeight;
+			offsetX = 0;
+			offsetY = 0;
+		} else {
+			Sure.sure(offset.width > 0);
+			Sure.sure(offset.x + offset.width <= originalWidth);
+			Sure.sure(offset.height > 0);
+			Sure.sure(offset.y + offset.height <= originalHeight);
+			Sure.sure(offset.x >= 0);
+			Sure.sure(offset.y >= 0);
+			width = offset.width;
+			height = offset.height;
+			offsetX = offset.x;
+			offsetY = offset.y;
+		}
+	}
+
+	/**
+	 * @returns current offset or null if none.
+	**/
+	public inline function getOffSet() {
+		if (width != originalWidth || height != originalHeight || offsetX != 0 || offsetY != 0) {
+			return {
+				x: offsetX,
+				y: offsetY,
+				width: width,
+				height: height
+			};
+		}
+		return null;
+	}
+
+	/**
+	 * Saves current offset overriding previous saves.
+	 * @param reset if given it will also remove current offset.
+	 */
+	public function saveOffSet(?reset:Bool) {
+		savedOffset = getOffSet();
+		if (reset) {
+			setOffset();
+		}
+	}
+
+	/**
+	 * Restores previously saved offset, if any.
+	 */
+	public function restoreOffset() {
+		if (savedOffset != null) {
+			setOffset(savedOffset);
+		}
+	}
+
+  /**
+   * Convert coordinates relative relative to the offset into absolute coordinatess.
+   **/
+	private inline function getCoordsIndex(x:Int, y:Int) {
+		var absoluteStart = offsetY * originalWidth + offsetX;
+		var absoluteIndex = (originalWidth * y) + x;
+		var index = absoluteStart + absoluteIndex;
+		return index;
+	}
+}

--- a/geometrize/runner/ImageRunner.hx
+++ b/geometrize/runner/ImageRunner.hx
@@ -3,6 +3,7 @@ package geometrize.runner;
 import geometrize.Model;
 import geometrize.Model.ShapeResult;
 import geometrize.bitmap.Bitmap;
+import geometrize.Util;
 import geometrize.bitmap.Rgba;
 import geometrize.runner.ImageRunnerOptions.Default;
 
@@ -23,6 +24,14 @@ class ImageRunner {
 	 */
 	public function new(inputImage:Bitmap, backgroundColor:Rgba) {
 		model = new Model(inputImage, backgroundColor);
+	}
+
+  /**
+   * The algorithm will only consider a region of the entire bitmap. 
+   * New shapes will be generated randombly but only inside this region.
+  **/
+	public inline function setOffset(?offset:Util.Rect):Void {
+		model.setOffset(offset);
 	}
 
 	/**

--- a/geometrize/runner/ImageRunner.hx
+++ b/geometrize/runner/ImageRunner.hx
@@ -28,6 +28,7 @@ class ImageRunner {
 
   /**
    * The algorithm will only consider a region of the entire bitmap. 
+   * If null is passed it will reset the offset (default behaviour)
    * New shapes will be generated randombly but only inside this region.
   **/
 	public inline function setOffset(?offset:Util.Rect):Void {

--- a/geometrize/runner/ImageRunnerOptions.hx
+++ b/geometrize/runner/ImageRunnerOptions.hx
@@ -1,6 +1,7 @@
 package geometrize.runner;
 
 import geometrize.shape.ShapeType;
+import geometrize.Util.Rect;
 
 /**
  * Encapsulates the parameters that may be passed to an image runner.
@@ -27,6 +28,11 @@ typedef ImageRunnerOptions = {
 	 * The number of times to mutate each candidate shape. By default `100`.
 	 */
 	@:optional var shapeMutationsPerStep:Int;
+
+  /**
+   * The algorithm will only consider a region of the entire bitmap. New shapes will be generated randombly but only inside this region.
+  **/
+	@:optional var bitmapOffset:Rect;
 }
 
 class Default {

--- a/geometrize/runner/ImageRunnerOptions.hx
+++ b/geometrize/runner/ImageRunnerOptions.hx
@@ -29,10 +29,6 @@ typedef ImageRunnerOptions = {
 	 */
 	@:optional var shapeMutationsPerStep:Int;
 
-  /**
-   * The algorithm will only consider a region of the entire bitmap. New shapes will be generated randombly but only inside this region.
-  **/
-	@:optional var bitmapOffset:Rect;
 }
 
 class Default {

--- a/geometrize/shape/Circle.hx
+++ b/geometrize/shape/Circle.hx
@@ -14,7 +14,8 @@ class Circle extends Ellipse {
 		rx = Std.random(32) + 1;
 		ry = rx;
 	}
-	
+		public function translate(vector:Util.Point) {}
+
 	override public function mutate():Void {
 		var r = Std.random(2);
 		switch (r) {

--- a/geometrize/shape/Circle.hx
+++ b/geometrize/shape/Circle.hx
@@ -14,7 +14,6 @@ class Circle extends Ellipse {
 		rx = Std.random(32) + 1;
 		ry = rx;
 	}
-		public function translate(vector:Util.Point) {}
 
 	override public function mutate():Void {
 		var r = Std.random(2);

--- a/geometrize/shape/Ellipse.hx
+++ b/geometrize/shape/Ellipse.hx
@@ -25,12 +25,14 @@ class Ellipse implements Shape {
 		this.xBound = xBound;
 		this.yBound = yBound;
 	}
-	  public function translate(vector:Util.Point) {
+
+  public function translate(vector:Util.Point) {
 		x = x + vector.x;
 		rx = rx + vector.x;
 		y = y + vector.y;
-		ry = ry + vector.y
+		ry = ry + vector.y;
   }
+
 	public function rasterize():Array<Scanline> {
 		var lines:Array<Scanline> = [];
 		var aspect:Float = rx / ry;

--- a/geometrize/shape/Ellipse.hx
+++ b/geometrize/shape/Ellipse.hx
@@ -26,13 +26,6 @@ class Ellipse implements Shape {
 		this.yBound = yBound;
 	}
 
-  public function translate(vector:Util.Point) {
-		x = x + vector.x;
-		rx = rx + vector.x;
-		y = y + vector.y;
-		ry = ry + vector.y;
-  }
-
 	public function rasterize():Array<Scanline> {
 		var lines:Array<Scanline> = [];
 		var aspect:Float = rx / ry;
@@ -99,4 +92,11 @@ class Ellipse implements Shape {
 	public function getSvgShapeData():String {
 		return "<ellipse cx=\"" + x + "\" cy=\"" + y + "\" rx=\"" + rx + "\" ry=\"" + ry + "\" " + SvgExporter.SVG_STYLE_HOOK + " />";
 	}
+
+  public function translate(vector:Util.Point) {
+		x = x + vector.x;
+		rx = rx + vector.x;
+		y = y + vector.y;
+		ry = ry + vector.y;
+  }
 }

--- a/geometrize/shape/Ellipse.hx
+++ b/geometrize/shape/Ellipse.hx
@@ -25,8 +25,12 @@ class Ellipse implements Shape {
 		this.xBound = xBound;
 		this.yBound = yBound;
 	}
-		public function translate(vector:Util.Point) {}
-
+	  public function translate(vector:Util.Point) {
+		x = x + vector.x;
+		rx = rx + vector.x;
+		y = y + vector.y;
+		ry = ry + vector.y
+  }
 	public function rasterize():Array<Scanline> {
 		var lines:Array<Scanline> = [];
 		var aspect:Float = rx / ry;

--- a/geometrize/shape/Ellipse.hx
+++ b/geometrize/shape/Ellipse.hx
@@ -25,7 +25,8 @@ class Ellipse implements Shape {
 		this.xBound = xBound;
 		this.yBound = yBound;
 	}
-	
+		public function translate(vector:Util.Point) {}
+
 	public function rasterize():Array<Scanline> {
 		var lines:Array<Scanline> = [];
 		var aspect:Float = rx / ry;

--- a/geometrize/shape/Line.hx
+++ b/geometrize/shape/Line.hx
@@ -25,9 +25,14 @@ class Line implements Shape {
 		
 		this.xBound = xBound;
 		this.yBound = yBound;
+	}	
+  
+  public function translate(vector:Util.Point) {
+		x1 = x1 + vector.x;
+		x2 = x2 + vector.x;
+		y1 = y1 + vector.y;
+		y2 = y2 + vector.y;
 	}
-		public function translate(vector:Util.Point) {}
-
 	public function rasterize():Array<Scanline> {
 		var lines:Array<Scanline> = [];
 		

--- a/geometrize/shape/Line.hx
+++ b/geometrize/shape/Line.hx
@@ -27,12 +27,6 @@ class Line implements Shape {
 		this.yBound = yBound;
 	}	
   
-  public function translate(vector:Util.Point) {
-		x1 = x1 + vector.x;
-		x2 = x2 + vector.x;
-		y1 = y1 + vector.y;
-		y2 = y2 + vector.y;
-	}
 	public function rasterize():Array<Scanline> {
 		var lines:Array<Scanline> = [];
 		
@@ -75,5 +69,12 @@ class Line implements Shape {
 	
 	public function getSvgShapeData():String {
 		return "<line x1=\"" + x1 + "\" y1=\"" + y1 + "\" x2=\"" + x2 + "\" y2=\"" + y2 + "\" " + SvgExporter.SVG_STYLE_HOOK + " />";
+	}
+  
+  public function translate(vector:Util.Point) {
+		x1 = x1 + vector.x;
+		x2 = x2 + vector.x;
+		y1 = y1 + vector.y;
+		y2 = y2 + vector.y;
 	}
 }

--- a/geometrize/shape/Line.hx
+++ b/geometrize/shape/Line.hx
@@ -26,7 +26,8 @@ class Line implements Shape {
 		this.xBound = xBound;
 		this.yBound = yBound;
 	}
-	
+		public function translate(vector:Util.Point) {}
+
 	public function rasterize():Array<Scanline> {
 		var lines:Array<Scanline> = [];
 		

--- a/geometrize/shape/QuadraticBezier.hx
+++ b/geometrize/shape/QuadraticBezier.hx
@@ -31,7 +31,15 @@ class QuadraticBezier implements Shape {
 		this.xBound = xBound;
 		this.yBound = yBound;
 	}
-		public function translate(vector:Util.Point) {}
+
+  public function translate(vector:Util.Point) {
+		x1 = x1 + vector.x;
+		x2 = x2 + vector.x;
+		cx = cx + vector.x;
+		cy = cy + vector.y;
+		y1 = y1 + vector.y;
+		y2 = y2 + vector.y;
+	}
 
 	public function rasterize():Array<Scanline> {
 		var lines:Array<Scanline> = [];

--- a/geometrize/shape/QuadraticBezier.hx
+++ b/geometrize/shape/QuadraticBezier.hx
@@ -31,7 +31,8 @@ class QuadraticBezier implements Shape {
 		this.xBound = xBound;
 		this.yBound = yBound;
 	}
-	
+		public function translate(vector:Util.Point) {}
+
 	public function rasterize():Array<Scanline> {
 		var lines:Array<Scanline> = [];
 		var points:Array<Point> = [];

--- a/geometrize/shape/QuadraticBezier.hx
+++ b/geometrize/shape/QuadraticBezier.hx
@@ -32,15 +32,6 @@ class QuadraticBezier implements Shape {
 		this.yBound = yBound;
 	}
 
-  public function translate(vector:Util.Point) {
-		x1 = x1 + vector.x;
-		x2 = x2 + vector.x;
-		cx = cx + vector.x;
-		cy = cy + vector.y;
-		y1 = y1 + vector.y;
-		y2 = y2 + vector.y;
-	}
-
 	public function rasterize():Array<Scanline> {
 		var lines:Array<Scanline> = [];
 		var points:Array<Point> = [];
@@ -110,5 +101,14 @@ class QuadraticBezier implements Shape {
 	
 	public function getSvgShapeData():String {
 		return "<path d=\"M" + x1 + " " + y1 + " Q " + cx + " " + cy + " " + x2 + " " + y2 + "\" " + SvgExporter.SVG_STYLE_HOOK + " />";
+	}
+
+  public function translate(vector:Util.Point) {
+		x1 = x1 + vector.x;
+		x2 = x2 + vector.x;
+		cx = cx + vector.x;
+		cy = cy + vector.y;
+		y1 = y1 + vector.y;
+		y2 = y2 + vector.y;
 	}
 }

--- a/geometrize/shape/Rectangle.hx
+++ b/geometrize/shape/Rectangle.hx
@@ -26,6 +26,13 @@ class Rectangle implements Shape {
 		this.yBound = yBound;
 	}
 	
+  public function translate(vector:Util.Point) {
+    x1= x1+vector.x;
+    x2=x2+vector.x;
+    y1=y1+vector.y;
+    y2=y2+vector.y;
+    trace('translate');
+  }
 	public function rasterize():Array<Scanline> {
 		var lines:Array<Scanline> = [];
 		var yMin:Int = Util.min(y1, y2);

--- a/geometrize/shape/Rectangle.hx
+++ b/geometrize/shape/Rectangle.hx
@@ -12,27 +12,27 @@ class Rectangle implements Shape {
 	public var y1:Int;
 	public var x2:Int;
 	public var y2:Int;
-	
+
 	public var xBound(default, null):Int;
 	public var yBound(default, null):Int;
-	
+
 	public function new(xBound:Int, yBound:Int) {
 		x1 = Std.random(xBound);
 		y1 = Std.random(yBound);
 		x2 = Util.clamp(x1 + Std.random(32) + 1, 0, xBound - 1);
 		y2 = Util.clamp(y1 + Std.random(32) + 1, 0, yBound - 1);
-		
+
 		this.xBound = xBound;
 		this.yBound = yBound;
 	}
-	
-  public function translate(vector:Util.Point) {
-    x1= x1+vector.x;
-    x2=x2+vector.x;
-    y1=y1+vector.y;
-    y2=y2+vector.y;
-    trace('translate');
-  }
+
+	public function translate(vector:Util.Point) {
+		x1 = x1 + vector.x;
+		x2 = x2 + vector.x;
+		y1 = y1 + vector.y;
+		y2 = y2 + vector.y;
+	}
+
 	public function rasterize():Array<Scanline> {
 		var lines:Array<Scanline> = [];
 		var yMin:Int = Util.min(y1, y2);
@@ -46,7 +46,7 @@ class Rectangle implements Shape {
 		}
 		return lines;
 	}
-	
+
 	public function mutate():Void {
 		var r = Std.random(2);
 		switch (r) {
@@ -58,7 +58,7 @@ class Rectangle implements Shape {
 				y2 = Util.clamp(y2 + Util.random(-16, 16), 0, yBound - 1);
 		}
 	}
-	
+
 	public function clone():Shape {
 		var rectangle = new Rectangle(xBound, yBound);
 		rectangle.x1 = x1;
@@ -67,16 +67,17 @@ class Rectangle implements Shape {
 		rectangle.y2 = y2;
 		return rectangle;
 	}
-	
+
 	public function getType():ShapeType {
 		return ShapeType.RECTANGLE;
 	}
-	
+
 	public function getRawShapeData():Array<Float> {
-		return [ Util.min(x1, x2), Util.min(y1, y2), Util.max(x1, x2), Util.max(y1, y2) ];
+		return [Util.min(x1, x2), Util.min(y1, y2), Util.max(x1, x2), Util.max(y1, y2)];
 	}
-	
+
 	public function getSvgShapeData():String {
-		return "<rect x=\"" + Util.min(x1, x2) + "\" y=\"" + Util.min(y1, y2) + "\" width=\"" + (Util.max(x1, x2) - Util.min(x1, x2)) + "\" height=\"" + (Util.max(y1, y2) - Util.min(y1, y2)) + "\" " + SvgExporter.SVG_STYLE_HOOK + " />";
+		return "<rect x=\"" + Util.min(x1, x2) + "\" y=\"" + Util.min(y1, y2) + "\" width=\"" + (Util.max(x1, x2) - Util.min(x1, x2)) + "\" height=\"" + (Util
+			.max(y1, y2) - Util.min(y1, y2)) + "\" " + SvgExporter.SVG_STYLE_HOOK + " />";
 	}
 }

--- a/geometrize/shape/Rectangle.hx
+++ b/geometrize/shape/Rectangle.hx
@@ -26,13 +26,6 @@ class Rectangle implements Shape {
 		this.yBound = yBound;
 	}
 
-	public function translate(vector:Util.Point) {
-		x1 = x1 + vector.x;
-		x2 = x2 + vector.x;
-		y1 = y1 + vector.y;
-		y2 = y2 + vector.y;
-	}
-
 	public function rasterize():Array<Scanline> {
 		var lines:Array<Scanline> = [];
 		var yMin:Int = Util.min(y1, y2);
@@ -79,5 +72,12 @@ class Rectangle implements Shape {
 	public function getSvgShapeData():String {
 		return "<rect x=\"" + Util.min(x1, x2) + "\" y=\"" + Util.min(y1, y2) + "\" width=\"" + (Util.max(x1, x2) - Util.min(x1, x2)) + "\" height=\"" + (Util
 			.max(y1, y2) - Util.min(y1, y2)) + "\" " + SvgExporter.SVG_STYLE_HOOK + " />";
+	}
+
+	public function translate(vector:Util.Point) {
+		x1 = x1 + vector.x;
+		x2 = x2 + vector.x;
+		y1 = y1 + vector.y;
+		y2 = y2 + vector.y;
 	}
 }

--- a/geometrize/shape/RotatedEllipse.hx
+++ b/geometrize/shape/RotatedEllipse.hx
@@ -29,13 +29,6 @@ class RotatedEllipse implements Shape {
 		this.yBound = yBound;
 	}
 	
-  public function translate(vector:Util.Point) {
-		x = x + vector.x;
-		rx = rx + vector.x;
-		y = y + vector.y;
-		ry = ry + vector.y;
-  }
-  
 	public function rasterize():Array<Scanline> {
 		var pointCount:Int = 20;
 		var points:Array<{x : Int, y: Int}> = [];
@@ -97,4 +90,12 @@ class RotatedEllipse implements Shape {
 		s += "</g>";
 		return s;
 	}
+
+  public function translate(vector:Util.Point) {
+		x = x + vector.x;
+		rx = rx + vector.x;
+		y = y + vector.y;
+		ry = ry + vector.y;
+  }
+  
 }

--- a/geometrize/shape/RotatedEllipse.hx
+++ b/geometrize/shape/RotatedEllipse.hx
@@ -33,7 +33,7 @@ class RotatedEllipse implements Shape {
 		x = x + vector.x;
 		rx = rx + vector.x;
 		y = y + vector.y;
-		ry = ry + vector.y
+		ry = ry + vector.y;
   }
   
 	public function rasterize():Array<Scanline> {

--- a/geometrize/shape/RotatedEllipse.hx
+++ b/geometrize/shape/RotatedEllipse.hx
@@ -28,8 +28,14 @@ class RotatedEllipse implements Shape {
 		this.xBound = xBound;
 		this.yBound = yBound;
 	}
-		public function translate(vector:Util.Point) {}
-
+	
+  public function translate(vector:Util.Point) {
+		x = x + vector.x;
+		rx = rx + vector.x;
+		y = y + vector.y;
+		ry = ry + vector.y
+  }
+  
 	public function rasterize():Array<Scanline> {
 		var pointCount:Int = 20;
 		var points:Array<{x : Int, y: Int}> = [];

--- a/geometrize/shape/RotatedEllipse.hx
+++ b/geometrize/shape/RotatedEllipse.hx
@@ -28,7 +28,8 @@ class RotatedEllipse implements Shape {
 		this.xBound = xBound;
 		this.yBound = yBound;
 	}
-	
+		public function translate(vector:Util.Point) {}
+
 	public function rasterize():Array<Scanline> {
 		var pointCount:Int = 20;
 		var points:Array<{x : Int, y: Int}> = [];

--- a/geometrize/shape/RotatedRectangle.hx
+++ b/geometrize/shape/RotatedRectangle.hx
@@ -29,8 +29,7 @@ class RotatedRectangle implements Shape {
 		this.xBound = xBound;
 		this.yBound = yBound;
 	}
-		public function translate(vector:Util.Point) {}
-
+	
 	public function rasterize():Array<Scanline> {
 		return Scanline.trim(Rasterizer.scanlinesForPolygon(getCornerPoints()), xBound, yBound);
 	}
@@ -108,5 +107,12 @@ class RotatedRectangle implements Shape {
 		var bry:Int = Std.int(ox2 * s + oy2 * c + cy);
 		
 		return [ { x : ulx, y : uly }, { x : urx, y : ury }, { x : brx, y : bry }, { x : blx, y : bly } ];
+	}
+
+  public function translate(vector:Util.Point) {
+		x1 = x1 + vector.x;
+		x2 = x2 + vector.x;
+		y1 = y1 + vector.y;
+		y2 = y2 + vector.y;
 	}
 }

--- a/geometrize/shape/RotatedRectangle.hx
+++ b/geometrize/shape/RotatedRectangle.hx
@@ -29,7 +29,8 @@ class RotatedRectangle implements Shape {
 		this.xBound = xBound;
 		this.yBound = yBound;
 	}
-	
+		public function translate(vector:Util.Point) {}
+
 	public function rasterize():Array<Scanline> {
 		return Scanline.trim(Rasterizer.scanlinesForPolygon(getCornerPoints()), xBound, yBound);
 	}

--- a/geometrize/shape/Shape.hx
+++ b/geometrize/shape/Shape.hx
@@ -7,38 +7,45 @@ import geometrize.rasterizer.Scanline;
  * @author Sam Twidale (http://samcodes.co.uk/)
  */
 interface Shape {
-  	public function translate(vector:Util.Point):Void;
 	/**
 	 * Creates a raster scanline representation of the shape.
 	 * @return	Array of raster scanlines representing the shape.
 	 */
 	public function rasterize():Array<Scanline>;
+
 	/**
 	 * Modifies the shape a little, typically with a random component.
 	 * For improving the shape's fit to a bitmap (trial-and-error style).
 	 */
 	public function mutate():Void;
+
 	/**
 	 * Creates a deep copy of the shape.
 	 * @return	A deep copy of the shape object.
 	 */
 	public function clone():Shape;
-	
+
 	/**
 	 * Gets the ShapeType of the shape.
 	 * @return The ShapeType of the shape.
 	 */
 	public function getType():ShapeType;
-	
+
 	/**
 	 * Gets a vector of data that represents the shape geometry, the format varies depending on the ShapeType.
 	 * @return The shape data.
 	 */
 	public function getRawShapeData():Array<Float>;
-	
+
 	/**
 	 * Gets a string that represents a SVG element that describes the shape geometry.
 	 * @return The SVG shape data that represents this shape.
 	 */
 	public function getSvgShapeData():String;
+
+	/**
+	 * Translate this shape by given vector. This is currently only needed for SVG output when using 
+   * Bitmap offsets so is not critical to implement if the usecase is another.
+	 */
+	public function translate(vector:Util.Point):Void;
 }

--- a/geometrize/shape/Shape.hx
+++ b/geometrize/shape/Shape.hx
@@ -7,6 +7,7 @@ import geometrize.rasterizer.Scanline;
  * @author Sam Twidale (http://samcodes.co.uk/)
  */
 interface Shape {
+  	public function translate(vector:Util.Point):Void;
 	/**
 	 * Creates a raster scanline representation of the shape.
 	 * @return	Array of raster scanlines representing the shape.

--- a/geometrize/shape/Triangle.hx
+++ b/geometrize/shape/Triangle.hx
@@ -30,7 +30,15 @@ class Triangle implements Shape {
 		this.xBound = xBound;
 		this.yBound = yBound;
 	}
-		public function translate(vector:Util.Point) {}
+	
+  public function translate(vector:Util.Point) {
+		x1 = x1 + vector.x;
+		x2 = x2 + vector.x;
+		x3 = x3 + vector.x;
+		y1 = y1 + vector.y;
+		y2 = y2 + vector.y;
+		y3 = y3 + vector.y;
+	}
 
 	public function rasterize():Array<Scanline> {
 		return Scanline.trim(Rasterizer.scanlinesForPolygon([ { x: x1, y: y1 }, { x: x2, y: y2 }, { x: x3, y: y3 } ]), xBound, yBound);

--- a/geometrize/shape/Triangle.hx
+++ b/geometrize/shape/Triangle.hx
@@ -30,7 +30,8 @@ class Triangle implements Shape {
 		this.xBound = xBound;
 		this.yBound = yBound;
 	}
-	
+		public function translate(vector:Util.Point) {}
+
 	public function rasterize():Array<Scanline> {
 		return Scanline.trim(Rasterizer.scanlinesForPolygon([ { x: x1, y: y1 }, { x: x2, y: y2 }, { x: x3, y: y3 } ]), xBound, yBound);
 	}

--- a/geometrize/shape/Triangle.hx
+++ b/geometrize/shape/Triangle.hx
@@ -31,15 +31,6 @@ class Triangle implements Shape {
 		this.yBound = yBound;
 	}
 	
-  public function translate(vector:Util.Point) {
-		x1 = x1 + vector.x;
-		x2 = x2 + vector.x;
-		x3 = x3 + vector.x;
-		y1 = y1 + vector.y;
-		y2 = y2 + vector.y;
-		y3 = y3 + vector.y;
-	}
-
 	public function rasterize():Array<Scanline> {
 		return Scanline.trim(Rasterizer.scanlinesForPolygon([ { x: x1, y: y1 }, { x: x2, y: y2 }, { x: x3, y: y3 } ]), xBound, yBound);
 	}
@@ -80,5 +71,14 @@ class Triangle implements Shape {
 	
 	public function getSvgShapeData():String {
 		return "<polygon points=\"" + x1 + "," + y1 + " " + x2 + "," + y2 + " " + x3 + "," + y3 + "\" " + SvgExporter.SVG_STYLE_HOOK + "/>";
+	}
+
+  public function translate(vector:Util.Point) {
+		x1 = x1 + vector.x;
+		x2 = x2 + vector.x;
+		x3 = x3 + vector.x;
+		y1 = y1 + vector.y;
+		y2 = y2 + vector.y;
+		y3 = y3 + vector.y;
 	}
 }


### PR DESCRIPTION
**This PR is not meant at all to be merged** but as a starting point to discuss this feature. Also kind of personal notes and updates on these research.

## What

Visually this will enable the users to select a region of the bitmap and apply the algorithm only there with custom options. In my experience I've noticed that some shape combinations will ignore some areas (often faces). Also could help with lines/curves that often are "too long" and ruin a landscape

Internally it isolates the region at the bitmap level so the whole algorithm runs in that context (reads, creates, mutates and render shapes only there). algorithm in new regions consume existing bitmap and collaborate with future sections/series. 

## Changes

 * Bitmap now supports the concept of offset (an internal rectangle inside).
    * By default is not enabled so it behaves just like now.
    * when set, some Bitmap members change the behavior (width, height, getPixel and setPixel ) 
 and interpret coordinates as relative to the offset.
    * Can be set dynamically and don't clone or destroy any bitmap or model (reuse existing ones), just some numbers in Bitmap that represent the offset.
    * I put all offset-related logic in a separated base class from which Bitmap inerith so its only responsibilty keeps being buffer/bytes/colors/render
     * setOffset is a method in the runner and not an option. when set it modifies runner's model and bitmaps. If can be called at any time in between steps. I needed to create setOffset method in runner, bitmap and model I thought it have more sense as a runner method, but it couldbe also implemented as an option to have them all in the same place.
     * updates runner's model's score. (same code as in the constructor) If I don't do it, I get errors `FAIL: Math.isFinite(result)'` on differencePartial(). I think updating the score solves the issue but I really don't know the impact or if it can be done better
      * At the bitmap level it support offset save/restore  since I needed this in Mode.new(). I will change that  probably if we get rid of Bitmap.create and implement a similar smarter method - and probably also remove support for this "save/restore" feature.
    * **(The worst part)** For it to support SVG I needed to implement Shape.translate(). Probably this is not required and it can be improved and optimized. basically after the step finish, I need to translate the new shape by the current offset and I'm doing it between steps. Is not big deal since is only one and just sums, but another way of support this could be storing the current offset in the shapes so themselves are responsible of managing this/ supporting offset?). Nevertheless if a new shape doesn't implement this it will keep working (incorrectly if using offsets and SVG)
 * bitmap image output  doesn't need this.

## Concerns: 

 * WIP - still testing.
 * **performance impact: on set/getPixel** since they need to support relative coordinates. 
 * I added a lots of code risking the library simplicity, mostly Shape.translate() rthat probably is not needed- WiIll keep trying to solve the problem differently.
 * Nevertheless I though about it and didn't found a way of implementing this feature in an auxiliary library.I'm not sure if these kind of features can be done without these kind of bit refactors.
 * not sure the consequences of reseting the **score** in the model @Tw1ddle ?

## Nice to have

 non rectangular regions for shapes/faces - rectangles are too artificial and pronounced... 